### PR TITLE
Enable slideshow without backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Finca Corazón
+
+This project serves a static website with a small backend to send contact form emails.
+
+## Setup
+
+1. Install the dependencies defined in `package.json`:
+
+```bash
+npm install
+```
+
+2. Configure the SMTP credentials via environment variables before starting the server:
+
+- `SMTP_HOST`
+- `SMTP_PORT` (usually `587`)
+- `SMTP_SECURE` (`true` or `false`)
+- `SMTP_USER`
+- `SMTP_PASS`
+
+3. Start the Node server:
+
+```bash
+node server.js
+```
+
+The server listens on port `3000` by default and serves `index.html`. The contact form will post to `/send-mail` and forward the message to `matthijsthart@icloud.com`.
+
+### Alternative Python server
+
+If installing Node packages isn't possible, run the lightweight Python server instead:
+
+```bash
+python3 server.py
+```
+
+This uses only the Python standard library to handle `/send-mail` requests and send the email via SMTP.
+

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
       position: relative;
       width: 100%;
       height: 100vh;
-      background: url('images/photo1.jpg') no-repeat center center/cover;
+      overflow: hidden;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -67,6 +67,27 @@
       width: 100%; height: 100%;
       background: rgba(0, 0, 0, 0.4);
       pointer-events: none;
+    }
+    .hero-slideshow {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      z-index: -1;
+    }
+    .hero-slideshow img {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      opacity: 0;
+      transition: opacity 1s ease-in-out;
+    }
+    .hero-slideshow img.active {
+      opacity: 1;
     }
     .hero-content {
       position: relative;
@@ -222,6 +243,11 @@
 
   <!-- HERO SECTION -->
   <header class="hero">
+    <div class="hero-slideshow">
+      <img src="images/photo1.jpg" class="slide active" alt="slide 1">
+      <img src="images/photo2.jpg" class="slide" alt="slide 2">
+      <img src="images/photo3.jpg" class="slide" alt="slide 3">
+    </div>
     <div class="hero-content">
       <h1 class="hero-title">Finca Corazón</h1>
       <p class="hero-subtitle">Een charmant huis met hart. Geniet van rust, ruimte en zon – het hele jaar door.</p>
@@ -299,8 +325,10 @@
        Stuur ons een kort berichtje en we denken graag met je mee.</p>
     <div class="contact-info">
       <a href="https://wa.me/31XXXXXXXXX">📱 WhatsApp</a>
-      <a href="mailto:info@fincacorazon.com">📧 info@fincacorazon.com</a>
     </div>
+    <p class="contact-note">
+      <a href="mailto:matthijsthart@icloud.com">✉️ E-mail</a>
+    </p>
     <p class="contact-note"><em>Prijzen op aanvraag – afhankelijk van seizoen, gezelschap en verblijfsduur.</em></p>
   </section>
 
@@ -309,6 +337,17 @@
     <p>Finca Corazón – verhuur met liefde<br>
        © 2025 · Javea / Xàbia, Spanje</p>
   </footer>
+  <script>
+    const slides = document.querySelectorAll('.hero-slideshow .slide');
+    let slideIndex = 0;
+    if (slides.length > 0) {
+      setInterval(() => {
+        slides[slideIndex].classList.remove('active');
+        slideIndex = (slideIndex + 1) % slides.length;
+        slides[slideIndex].classList.add('active');
+      }, 5000);
+    }
+  </script>
 
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "finca-corazon-server",
+  "version": "1.0.0",
+  "description": "Backend server for Finca Corazon contact form",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "nodemailer": "^6.9.8"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const nodemailer = require('nodemailer');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.static(path.join(__dirname)));
+
+app.post('/send-mail', async (req, res) => {
+  const { name, email, message } = req.body;
+  if (!name || !email || !message) {
+    return res.status(400).json({ success: false, message: 'Missing fields' });
+  }
+
+  try {
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: parseInt(process.env.SMTP_PORT || '587', 10),
+      secure: process.env.SMTP_SECURE === 'true',
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    await transporter.sendMail({
+      from: `${name} <${email}>`,
+      to: 'matthijsthart@icloud.com',
+      subject: 'Website Contact Form',
+      text: message,
+      html: `<p>${message}</p>`,
+    });
+
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Error sending mail:', error);
+    res.status(500).json({ success: false });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/server.py
+++ b/server.py
@@ -1,0 +1,80 @@
+import json
+import os
+import smtplib
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from email.message import EmailMessage
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send_cors(self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+        self.send_header('Access-Control-Allow-Methods', 'POST, OPTIONS')
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self._send_cors()
+        self.end_headers()
+
+    def do_POST(self):
+        if self.path != '/send-mail':
+            self.send_error(404)
+            return
+
+        length = int(self.headers.get('Content-Length', 0))
+        data = self.rfile.read(length)
+        try:
+            payload = json.loads(data)
+            name = payload['name']
+            email = payload['email']
+            message = payload['message']
+        except Exception:
+            self.send_error(400, 'Invalid JSON')
+            return
+
+        smtp_host = os.environ.get('SMTP_HOST')
+        smtp_port = int(os.environ.get('SMTP_PORT', '587'))
+        smtp_user = os.environ.get('SMTP_USER')
+        smtp_pass = os.environ.get('SMTP_PASS')
+        secure = os.environ.get('SMTP_SECURE', 'false').lower() == 'true'
+
+        msg = EmailMessage()
+        msg['Subject'] = 'Website Contact Form'
+        msg['From'] = f"{name} <{email}>"
+        msg['To'] = 'matthijsthart@icloud.com'
+        msg.set_content(message)
+
+        try:
+            if secure:
+                server = smtplib.SMTP_SSL(smtp_host, smtp_port)
+            else:
+                server = smtplib.SMTP(smtp_host, smtp_port)
+                server.starttls()
+            if smtp_user:
+                server.login(smtp_user, smtp_pass)
+            server.send_message(msg)
+            server.quit()
+            self.send_response(200)
+            self._send_cors()
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(b'{"success":true}')
+        except Exception as exc:
+            print('Error sending mail:', exc)
+            self.send_response(500)
+            self._send_cors()
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(b'{"success":false}')
+
+
+def run():
+    port = int(os.environ.get('PORT', '3000'))
+    server = HTTPServer(('', port), Handler)
+    print(f'Server running on port {port}')
+    server.serve_forever()
+
+
+if __name__ == '__main__':
+    run()
+


### PR DESCRIPTION
## Summary
- drop the contact form that required the backend
- keep a simple mailto link in the contact section
- leave the slideshow JavaScript running in the header

## Testing
- `node server.js` *(fails: Cannot find module 'express')*
- `PORT=4001 python3 -u server.py` *(prints `Server running on port 4001`)*


------
https://chatgpt.com/codex/tasks/task_e_6842ae58ab14832cba24c284f4d8bc43