### PR TITLE
Fix initial page scroll to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -493,6 +493,14 @@
         navMenu.classList.toggle('active');
       });
     }
+
+    // Scroll to the top on initial load even if a hash is present
+    window.addEventListener('load', () => {
+      if (window.location.hash) {
+        history.replaceState(null, '', window.location.pathname);
+        window.scrollTo(0, 0);
+      }
+    });
   </script>
 
 </body>


### PR DESCRIPTION
## Summary
- force page to scroll to top on initial load regardless of fragment

## Testing
- `npm install`
- `npm start` (fails here because server just runs)

------
https://chatgpt.com/codex/tasks/task_e_6842d9642098832c9bf4c032f27557e5