### PR TITLE
Update header hamburger color on scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,6 +268,10 @@
       display: block;
       width: 25px;
       height: 3px;
+      background: #fff;
+      transition: background-color 0.3s;
+    }
+    .nav-toggle.dark span {
       background: #333;
     }
     .nav-menu {
@@ -472,6 +476,19 @@
         });
       });
     }
+
+    const heroSection = document.getElementById('home');
+    function updateNavColor() {
+      if (!navToggle) return;
+      const threshold = heroSection.offsetHeight - navToggle.offsetHeight;
+      if (window.scrollY > threshold) {
+        navToggle.classList.add('dark');
+      } else {
+        navToggle.classList.remove('dark');
+      }
+    }
+    window.addEventListener('scroll', updateNavColor);
+    window.addEventListener('load', updateNavColor);
 
     // Scroll to the top on initial load even if a hash is present
     window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- make hamburger lines white by default
- switch to dark gray when scrolling past the hero section

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6842efc9bf08832cbdbe3ecefc6a7b7f