### PR TITLE
Set slideshow transition to 2.5 seconds

### DIFF
--- a/index.html
+++ b/index.html
@@ -539,7 +539,7 @@
         slides[currentSlide].classList.remove('active');
         currentSlide = (currentSlide + 1) % slides.length;
         slides[currentSlide].classList.add('active');
-      }, 4500);
+      }, 2500);
     }
 
     const navToggle = document.querySelector('.nav-toggle');


### PR DESCRIPTION
## Summary
- reduce the slideshow interval from 4.5s to 2.5s

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68639db87abc832c88bcecfc55bcc6e5