### PR TITLE
Enable arrow key navigation in lightbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -624,6 +624,12 @@
     showImage(currentIndex - 1);
   });
 
+  document.addEventListener('keydown', e => {
+    if (!lightbox.classList.contains('active')) return;
+    if (e.key === 'ArrowRight') showImage(currentIndex + 1);
+    if (e.key === 'ArrowLeft') showImage(currentIndex - 1);
+  });
+
   closeBtn.addEventListener('click', () => {
     lightbox.classList.remove('active');
   });


### PR DESCRIPTION
## Summary
- add document-level keydown listener that allows lightbox navigation with ArrowRight/ArrowLeft keys when lightbox is active

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688dcea4871c832c9728358f0fd94cfe