### PR TITLE
Use Playfair Display for headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,15 +6,19 @@
   <title>Finca el Corazón – Javea / Xàbia</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link 
-    href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap" 
-    rel="stylesheet"
-  >
-  <style>
-    /* ------------ Global Styles ------------ */
-    * {
-      margin: 0;
-      padding: 0;
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap"
+      rel="stylesheet"
+    >
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap"
+      rel="stylesheet"
+    >
+    <style>
+      /* ------------ Global Styles ------------ */
+      * {
+        margin: 0;
+        padding: 0;
       box-sizing: border-box;
     }
     body {
@@ -47,15 +51,19 @@
       transform: translateY(20px);
       transition: opacity 0.6s ease, transform 0.6s ease;
     }
-    .fade-in.visible {
-      opacity: 1;
-      transform: none;
-    }
-    h2 {
-      font-size: 2rem;
-      margin-bottom: 20px;
-      color: #222;
-      text-align: center;
+      .fade-in.visible {
+        opacity: 1;
+        transform: none;
+      }
+      h1,
+      h2 {
+        font-family: 'Playfair Display', serif;
+      }
+      h2 {
+        font-size: 2rem;
+        margin-bottom: 20px;
+        color: #222;
+        text-align: center;
     }
     p {
       margin-bottom: 20px;


### PR DESCRIPTION
## Summary
- Load Playfair Display from Google Fonts for serif headings
- Style h1 and h2 elements with Playfair Display while keeping Montserrat for body text

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dafd2b1d0832c8323ad6570bdc32e