### PR TITLE
Move header menu to top right

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,7 +337,8 @@
     .navbar {
       position: fixed;
       top: 10px;
-      left: 10px;
+      right: 10px;
+      left: auto;
       z-index: 3;
       display: block;
     }
@@ -345,6 +346,7 @@
       display: flex;
       gap: 20px;
       color: #fff;
+      justify-content: flex-end;
     }
     .nav-toggle {
       background: none;
@@ -379,11 +381,12 @@
       flex-direction: column;
       position: absolute;
       top: 40px;
-      left: 10px;
+      right: 10px;
+      left: auto;
       background: rgba(0, 0, 0, 0.8);
       padding: 10px 15px;
       border-radius: 4px;
-      text-align: left;
+      text-align: right;
     }
     .nav-menu.active {
       display: flex;


### PR DESCRIPTION
## Summary
- Reposition header navigation to the top-right of the page
- Align mobile dropdown menu to open from the right

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689db13d4814832caa276a89d0162fbc