### PR TITLE
Center tagline in Voorzieningen section

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,11 @@
     }
 
     /* ------------ Section: Voorzieningen ------------ */
+    #voorzieningen > p {
+      text-align: center;
+      max-width: 800px;
+      margin: 0 auto 20px;
+    }
     .features-grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));


### PR DESCRIPTION
## Summary
- Center the tagline text under the "Voorzieningen" section by adding a dedicated CSS rule.

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689db6136214832c815d3e843063ef77