### PR TITLE
Align hamburger menu to top-left after scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,6 +356,10 @@
       display: flex;
       justify-content: center;
     }
+    .navbar.scrolled {
+      justify-content: flex-start;
+      padding-left: 10px;
+    }
     .nav-links {
       display: flex;
       gap: 20px;
@@ -396,12 +400,12 @@
       flex-direction: column;
       position: absolute;
       top: 40px;
-      right: 10px;
-      left: auto;
+      left: 10px;
+      right: auto;
       background: rgba(0, 0, 0, 0.8);
       padding: 10px 15px;
       border-radius: 4px;
-      text-align: right;
+      text-align: left;
     }
     .nav-menu.active {
       display: flex;


### PR DESCRIPTION
## Summary
- Show hamburger menu in the top-left corner after scrolling by left-aligning the navbar
- Open the dropdown menu from the left side to match the new hamburger position

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dbb71c580832c9e63ac894032a1b3