### PR TITLE
Make nav responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,6 +455,12 @@
       h2 {
         font-size: 1.75rem;
       }
+      .nav-links {
+        display: none;
+      }
+      .nav-toggle {
+        display: flex;
+      }
     }
   </style>
 </head>
@@ -487,7 +493,7 @@
           <li><a href="#omgeving">Omgeving</a></li>
           <li><a href="#contact">Boeking &amp; Contact</a></li>
         </ul>
-        <button class="nav-toggle hidden" aria-label="Menu">
+        <button class="nav-toggle" aria-label="Menu">
           <span></span>
           <span></span>
           <span></span>
@@ -682,16 +688,21 @@
       });
     }
 
-    if (navMenu) {
-      navMenu.querySelectorAll('a').forEach(link => {
-        link.addEventListener('click', () => {
-          navMenu.classList.remove('active');
+      if (navMenu) {
+        navMenu.querySelectorAll('a').forEach(link => {
+          link.addEventListener('click', () => {
+            navMenu.classList.remove('active');
+          });
         });
+      }
+      window.addEventListener('resize', () => {
+        if (window.innerWidth > 768 && navMenu) {
+          navMenu.classList.remove('active');
+        }
       });
-    }
-    const navbar = document.querySelector('.navbar');
-    function handleNavbarScroll() {
-      if (!navbar) return;
+      const navbar = document.querySelector('.navbar');
+      function handleNavbarScroll() {
+        if (!navbar) return;
       if (window.scrollY > 0) {
         navbar.classList.add('scrolled');
       } else {


### PR DESCRIPTION
## Summary
- Show burger button by default and hide desktop links on small screens
- Add resize handler to close nav menu when resizing wider than mobile

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dc3894730832c801a20c7055d7b73