### PR TITLE
Show mobile nav separator icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -463,8 +463,24 @@
     .nav-menu.active {
       display: flex;
     }
+    /* Plaats menu-items onder elkaar en centreer */
     .nav-menu li {
-      margin: 5px 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    /* Voeg het boho swirl icoon toe als scheiding tussen items */
+    .nav-menu li + li::before {
+      content: "";
+      display: block;
+      width: 20px; /* breedte icoon */
+      height: 20px; /* hoogte icoon */
+      background-image: url("images/boho_swirl_icon_transparent.png"); /* pad naar icoon */
+      background-size: contain;
+      background-repeat: no-repeat;
+      filter: invert(1); /* icoon zichtbaar op donkere achtergrond */
+      margin: 12px 0; /* ruimte boven en onder icoon */
     }
     .nav-menu a {
       color: #fff;


### PR DESCRIPTION
## Summary
- center nav menu items vertically and insert boho swirl icon between links
- invert icon color to keep it visible against dark mobile nav background

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dc8e8b0ac832cb32f4a3e4d3ead48