### PR TITLE
Use Pacifico font for hero title

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,15 @@
       href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700&display=swap"
       rel="stylesheet"
     >
-    <link
-      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap"
-      rel="stylesheet"
-    >
-    <style>
+      <link
+        href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap"
+        rel="stylesheet"
+      >
+      <link
+        href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap"
+        rel="stylesheet"
+      >
+      <style>
       /* ------------ Global Styles ------------ */
       * {
         margin: 0;
@@ -126,11 +130,13 @@
       .slideshow img.active {
         opacity: 1;
       }
-    .hero-title {
-      font-size: 3rem;
-      font-weight: 700;
-      margin-bottom: 10px;
-    }
+      .hero-title {
+        font-family: 'Pacifico', cursive;
+        font-size: 3rem;
+        color: #E9DFD0;
+        text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.4);
+        margin-bottom: 10px;
+      }
     .hero-subtitle {
       font-size: 1.25rem;
       font-weight: 300;


### PR DESCRIPTION
## Summary
- add Google Fonts link for Pacifico
- style hero title with Pacifico font, #E9DFD0 color and subtle text shadow

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac39107840832cad3355969d7d2d37