### PR TITLE
Improve image loading performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -499,15 +499,15 @@
   <!-- HERO SECTION -->
   <header id="home" class="hero">
     <div class="slideshow">
-      <img src="PHOTO-2025-05-22-09-40-54 14.JPG" alt="Slideshow afbeelding 1">
-      <img src="PHOTO-2025-05-22-09-40-54 8.JPG" alt="Slideshow afbeelding 2">
-      <img src="PHOTO-2025-05-22-09-41-58 5.JPG" alt="Slideshow afbeelding 3">
-      <img src="dji_fly_20250605_134540_0037_1749124547712_photo.JPG" alt="Slideshow afbeelding 4">
-      <img src="images/photo11.jpg" alt="Slideshow afbeelding 5">
-      <img src="PHOTO-2025-05-22-09-41-58 16.JPG" alt="Slideshow afbeelding 6">
-      <img src="dji_fly_20250605_134034_0028_1749124595923_photo.JPG" alt="Slideshow afbeelding 7">
-      <img src="dji_fly_20250605_185802_0042_1749153287792_photo.JPG" alt="Slideshow afbeelding 8">
-      <img src="IMG_4567.JPG" alt="Slideshow afbeelding 9">
+      <img src="PHOTO-2025-05-22-09-40-54 14.JPG" alt="Slideshow afbeelding 1" loading="eager" decoding="sync" fetchpriority="high">
+      <img src="PHOTO-2025-05-22-09-40-54 8.JPG" alt="Slideshow afbeelding 2" loading="lazy" decoding="async" fetchpriority="low">
+      <img src="PHOTO-2025-05-22-09-41-58 5.JPG" alt="Slideshow afbeelding 3" loading="lazy" decoding="async" fetchpriority="low">
+      <img src="dji_fly_20250605_134540_0037_1749124547712_photo.JPG" alt="Slideshow afbeelding 4" loading="lazy" decoding="async" fetchpriority="low">
+      <img src="images/photo11.jpg" alt="Slideshow afbeelding 5" loading="lazy" decoding="async" fetchpriority="low">
+      <img src="PHOTO-2025-05-22-09-41-58 16.JPG" alt="Slideshow afbeelding 6" loading="lazy" decoding="async" fetchpriority="low">
+      <img src="dji_fly_20250605_134034_0028_1749124595923_photo.JPG" alt="Slideshow afbeelding 7" loading="lazy" decoding="async" fetchpriority="low">
+      <img src="dji_fly_20250605_185802_0042_1749153287792_photo.JPG" alt="Slideshow afbeelding 8" loading="lazy" decoding="async" fetchpriority="low">
+      <img src="IMG_4567.JPG" alt="Slideshow afbeelding 9" loading="lazy" decoding="async" fetchpriority="low">
     </div>
     <div class="hero-content">
       <h1 class="hero-title">Finca el Corazón</h1>
@@ -633,35 +633,35 @@
   <section class="gallery-section fade-in" id="galerij">
     <h2>Foto's van de Finca</h2>
     <div class="masonry-gallery">
-      <img src="images/photo1.jpg" alt="Foto 1">
-      <img src="images/photo2.jpg" alt="Foto 2">
-      <img src="images/photo3.jpg" alt="Foto 3">
-      <img src="images/photo4.jpg" alt="Foto 4">
-      <img src="images/photo5.jpg" alt="Foto 5">
-      <img src="images/photo6.jpg" alt="Foto 6">
-      <img src="images/photo7.jpg" alt="Foto 7">
-      <img src="images/photo8.jpg" alt="Foto 8">
-      <img src="images/photo9.jpg" alt="Foto 9">
-      <img src="images/photo10.jpg" alt="Foto 10">
-      <img src="images/photo11.jpg" alt="Foto 11">
-      <img src="9e4b3e6c-a962-4ff8-bec0-b6423a822563.JPG" alt="Foto 12">
-      <img src="PHOTO-2025-05-22-09-41-58 19.JPG" alt="Foto 13">
-      <img src="dji_fly_20250603_193118_0003_1749122678727_photo.JPG" alt="Foto 14">
-      <img src="dji_fly_20250605_134540_0037_1749124547712_photo.JPG" alt="Foto 15">
-      <img src="PHOTO-2025-05-22-09-41-58 16.JPG" alt="Foto 16">
-      <img src="dji_fly_20250605_134034_0028_1749124595923_photo.JPG" alt="Foto 17">
-      <img src="dji_fly_20250605_185802_0042_1749153287792_photo.JPG" alt="Foto 18">
-      <img src="IMG_4554.JPG" alt="Foto 19">
-      <img src="IMG_4567.JPG" alt="Foto 20">
-      <img src="IMG_4571.JPG" alt="Foto 21">
-      <img src="PHOTO-2025-05-22-09-40-54 14.JPG" alt="Foto 22">
-      <img src="PHOTO-2025-05-22-09-40-54 8.JPG" alt="Foto 23">
-      <img src="PHOTO-2025-05-22-09-41-58 5.JPG" alt="Foto 24">
-      <img src="PHOTO-2025-05-22-09-41-58 14.JPG" alt="Foto 25">
-      <img src="PHOTO-2025-05-22-09-41-58.JPG" alt="Foto 26">
-      <img src="PHOTO-2025-05-22-09-42-58 11.JPG" alt="Foto 27">
-      <img src="PHOTO-2025-05-22-09-42-58.JPG" alt="Foto 28">
-      <img src="PHOTO-2025-05-22-09-44-07 4.JPG" alt="Foto 29">
+      <img src="images/photo1.jpg" alt="Foto 1" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="images/photo2.jpg" alt="Foto 2" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="images/photo3.jpg" alt="Foto 3" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="images/photo4.jpg" alt="Foto 4" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="images/photo5.jpg" alt="Foto 5" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="images/photo6.jpg" alt="Foto 6" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="images/photo7.jpg" alt="Foto 7" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="images/photo8.jpg" alt="Foto 8" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="images/photo9.jpg" alt="Foto 9" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="images/photo10.jpg" alt="Foto 10" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="images/photo11.jpg" alt="Foto 11" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="9e4b3e6c-a962-4ff8-bec0-b6423a822563.JPG" alt="Foto 12" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="PHOTO-2025-05-22-09-41-58 19.JPG" alt="Foto 13" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="dji_fly_20250603_193118_0003_1749122678727_photo.JPG" alt="Foto 14" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="dji_fly_20250605_134540_0037_1749124547712_photo.JPG" alt="Foto 15" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="PHOTO-2025-05-22-09-41-58 16.JPG" alt="Foto 16" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="dji_fly_20250605_134034_0028_1749124595923_photo.JPG" alt="Foto 17" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="dji_fly_20250605_185802_0042_1749153287792_photo.JPG" alt="Foto 18" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="IMG_4554.JPG" alt="Foto 19" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="IMG_4567.JPG" alt="Foto 20" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="IMG_4571.JPG" alt="Foto 21" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="PHOTO-2025-05-22-09-40-54 14.JPG" alt="Foto 22" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="PHOTO-2025-05-22-09-40-54 8.JPG" alt="Foto 23" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="PHOTO-2025-05-22-09-41-58 5.JPG" alt="Foto 24" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="PHOTO-2025-05-22-09-41-58 14.JPG" alt="Foto 25" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="PHOTO-2025-05-22-09-41-58.JPG" alt="Foto 26" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="PHOTO-2025-05-22-09-42-58 11.JPG" alt="Foto 27" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="PHOTO-2025-05-22-09-42-58.JPG" alt="Foto 28" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="PHOTO-2025-05-22-09-44-07 4.JPG" alt="Foto 29" loading="lazy" decoding="async" width="1200" height="800">
     </div>
   </section>
 
@@ -671,12 +671,12 @@
   <section class="omgeving fade-in" id="omgeving">
     <h2>Omgeving Javea/Xabia</h2>
     <div class="masonry-gallery">
-      <img src="IMG_3770 2.JPG" alt="Omgeving 1">
-      <img src="IMG_3771 2.JPG" alt="Omgeving 2">
-      <img src="istockphoto-1192838714-1024x1024.JPG" alt="Omgeving 3">
-      <img src="istockphoto-1454769262-1024x1024.JPG" alt="Omgeving 4">
-      <img src="istockphoto-2108599336-1024x1024.JPG" alt="Omgeving 5">
-      <img src="istockphoto-538323831-1024x1024.JPG" alt="Omgeving 6">
+      <img src="IMG_3770 2.JPG" alt="Omgeving 1" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="IMG_3771 2.JPG" alt="Omgeving 2" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="istockphoto-1192838714-1024x1024.JPG" alt="Omgeving 3" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="istockphoto-1454769262-1024x1024.JPG" alt="Omgeving 4" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="istockphoto-2108599336-1024x1024.JPG" alt="Omgeving 5" loading="lazy" decoding="async" width="1200" height="800">
+      <img src="istockphoto-538323831-1024x1024.JPG" alt="Omgeving 6" loading="lazy" decoding="async" width="1200" height="800">
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- prioritize the first hero slideshow image for immediate rendering and defer the rest with lazy loading
- add lazy loading, async decoding, and explicit dimensions to gallery and omgeving imagery to reduce initial payload

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3b0914c1c8332bc57d05ab617f501