### PR TITLE
Fix lazy-loading compatibility for iOS Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,6 +722,21 @@
   <script src="https://unpkg.com/feather-icons"></script>
   <script>
     feather.replace();
+    const isIos = /iP(ad|hone|od)/.test(navigator.userAgent);
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+    if (isIos && isSafari) {
+      document.querySelectorAll('img[loading="lazy"]').forEach(img => {
+        img.setAttribute('loading', 'eager');
+        if (!img.complete) {
+          const currentSrc = img.getAttribute('src');
+          if (currentSrc) {
+            img.src = currentSrc;
+          }
+        }
+      });
+    }
+
     const slides = document.querySelectorAll('.slideshow img');
     let currentSlide = 0;
     if (slides.length) {


### PR DESCRIPTION
## Summary
- detect iOS Safari browsers and force eager loading for lazily marked images so the finca photos render reliably

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e3b21f1c288332afd6ac1ebc043fff