### PR TITLE
Vernieuw fotogalerij: 11 nieuwe foto's, swaps en opruiming

### DIFF
--- a/index.html
+++ b/index.html
@@ -1377,9 +1377,16 @@
       <div class="g span-7 reveal-l"><img src="images/2-PHOTO-2026-03-05-09-45-56.jpg" alt="Finca impressie" loading="lazy" decoding="async"></div>
       <div class="g span-5 reveal-l"><img src="images/3-PHOTO-2026-02-10-11-23-55.jpg" alt="Keuken" loading="lazy" decoding="async"></div>
 
-      <!-- Layout C: 5+7 -->
-      <div class="g span-5 reveal-l"><img src="images/5-PHOTO-2025-05-22-09-42-58%208%202.jpg" alt="Badkamer" loading="lazy" decoding="async"></div>
-      <div class="g span-7 reveal-l"><img src="images/dji-fly-20250605-134034-0028-1749124595923-photo.jpg" alt="Drone foto zwembad" loading="lazy" decoding="async"></div>
+      <!-- Layout C: badkamer + 4 detail-foto's + drone -->
+      <div class="g span-12 reveal-l"><img src="images/5-PHOTO-2025-05-22-09-42-58%208%202.jpg" alt="Badkamer" loading="lazy" decoding="async"></div>
+
+      <!-- Verplaatste detailrij: 4 foto's -->
+      <div class="g span-3 reveal-l"><img src="images/bbq%20links.PNG" alt="Buitenkeuken met BBQ" loading="lazy" decoding="async"></div>
+      <div class="g span-3 reveal-l"><img src="images/buitenkeuken%20rechts.PNG" alt="Buitenkeuken vanaf rechts" loading="lazy" decoding="async"></div>
+      <div class="g span-3 reveal-l"><img src="images/muurtje%20met%20pot.PNG" alt="Detail tuinmuur" loading="lazy" decoding="async"></div>
+      <div class="g span-3 reveal-l"><img src="images/open%20haard%20binnen.PNG" alt="Woonkamer met open haard" loading="lazy" decoding="async"></div>
+
+      <div class="g span-12 reveal-l"><img src="images/dji-fly-20250605-134034-0028-1749124595923-photo.jpg" alt="Drone foto zwembad" loading="lazy" decoding="async"></div>
 
       <!-- Layout D: 4+4+4 -->
       <div class="g span-4 reveal-l"><img src="images/slaapkamer%20guesthouse.PNG" alt="Slaapkamer guesthouse" loading="lazy" decoding="async"></div>
@@ -1421,14 +1428,8 @@
       <div class="g span-4 reveal-l"><img src="images/dubbel%20bed.PNG" alt="Slaapkamer met dubbel bed" loading="lazy" decoding="async"></div>
       <div class="g span-4 reveal-l"><img src="images/zwembad%20voor.PNG" alt="Zwembad vooraanzicht" loading="lazy" decoding="async"></div>
 
-      <!-- Layout M: 6+6 -->
-      <div class="g span-6 reveal-l"><img src="images/img-4567.jpg" alt="Pergola met zicht op tuin" loading="lazy" decoding="async"></div>
-      <div class="g span-6 reveal-l"><img src="images/bbq%20links.PNG" alt="Buitenkeuken met BBQ" loading="lazy" decoding="async"></div>
-
-      <!-- Layout M2: 4+4+4 — extra detailfoto's -->
-      <div class="g span-4 reveal-l"><img src="images/buitenkeuken%20rechts.PNG" alt="Buitenkeuken vanaf rechts" loading="lazy" decoding="async"></div>
-      <div class="g span-4 reveal-l"><img src="images/muurtje%20met%20pot.PNG" alt="Detail tuinmuur" loading="lazy" decoding="async"></div>
-      <div class="g span-4 reveal-l"><img src="images/open%20haard%20binnen.PNG" alt="Woonkamer met open haard" loading="lazy" decoding="async"></div>
+      <!-- Layout M: pergola full width -->
+      <div class="g span-12 reveal-l"><img src="images/img-4567.jpg" alt="Pergola met zicht op tuin" loading="lazy" decoding="async"></div>
 
       <!-- Layout N: full width -->
       <div class="g span-12 reveal-l"><img src="images/1-IMG_0988.jpg" alt="Finca el Corazón overzicht" loading="lazy" decoding="async"></div>


### PR DESCRIPTION
## Wat verandert er

### 8 swaps in galerij + hero
| Nieuw | Vervangt |
|---|---|
| `bank binnen.PNG` | `photo-2025-05-22-09-41-58-5.jpg` (woonkamer + hero) |
| `bbq links.PNG` | `img-4571.jpg` (buitenkeuken) |
| `binnen eettafel.PNG` | `HIHIPHOTO-2025-05-22-09-41-58 10.JPG` |
| `boven af drone.PNG` | `dji-fly-...-0037.jpg` (drone hero galerij) |
| `dubbel bed.PNG` | `photo-2025-05-22-09-42-58-7.jpg` |
| `slaapkamer guesthouse.PNG` | `4-PHOTO-2025-05-22-09-42-58 9 2.jpg` |
| `veranda 1.PNG` | `photo-2025-05-22-09-41-58-19.jpg` |
| `zwembad voor.PNG` | `XXPHOTO-2025-05-22-09-43-25 14.JPG` |

### 3 nieuwe foto's toegevoegd
- `buitenkeuken rechts.PNG`
- `muurtje met pot.PNG`
- `open haard binnen.PNG`

### Layout-verandering
De 4 detailfoto's (`bbq links`, `buitenkeuken rechts`, `muurtje met pot`, `open haard binnen`) staan als rij van 4 vlak na de badkamer (4e foto van boven). De pergola die overbleef is nu full-width.

### Opruiming
27 ongebruikte/dode bestanden verwijderd uit `images/`:
- 8× `-min.jpg` kopieën
- 7× generieke `photoN.jpg`
- 8× vervangen originelen
- 4× overige ongebruikte bestanden (oude drone, UUID-files, ongebruikte stockfoto)

Repo is ~50 MB lichter.

## Test plan
- [ ] Galerij doorlopen op desktop — controleer dat alle 11 nieuwe foto's correct verschijnen
- [ ] Galerij doorlopen op iPhone — check volgorde en bijsnijding van de 4-detailrij
- [ ] Hero-slideshow checken — `bank binnen.PNG` moet als eerste verschijnen
- [ ] Geen broken images (404's) in de console

https://claude.ai/code/session_013UnB3bHaxkZnj5vBS3fQba

---
_Generated by [Claude Code](https://claude.ai/code/session_013UnB3bHaxkZnj5vBS3fQba)_