### PR TITLE
Voeg niche-detailfoto toe halverwege galerij

### DIFF
--- a/index.html
+++ b/index.html
@@ -1401,9 +1401,10 @@
       <div class="g span-8 reveal-l"><img src="images/photo-2025-05-22-09-41-58-16.jpg" alt="Zithoek buiten" loading="lazy" decoding="async"></div>
       <div class="g span-4 reveal-l"><img src="images/photo-2025-05-22-09-41-26-17.jpg" alt="Detail" loading="lazy" decoding="async"></div>
 
-      <!-- Layout G: 4+8 -->
+      <!-- Layout G: 4+4+4 -->
       <div class="g span-4 reveal-l"><img src="images/photo-2025-05-22-09-41-26-18.jpg" alt="Buitenruimte" loading="lazy" decoding="async"></div>
-      <div class="g span-8 reveal-l"><img src="images/photo-2025-05-22-09-44-07-4.jpg" alt="Avondsfeer" loading="lazy" decoding="async"></div>
+      <div class="g span-4 reveal-l"><img src="images/niche_01_full.jpg" alt="Detail trapnis met kruik" loading="lazy" decoding="async"></div>
+      <div class="g span-4 reveal-l"><img src="images/photo-2025-05-22-09-44-07-4.jpg" alt="Avondsfeer" loading="lazy" decoding="async"></div>
 
       <!-- Layout H: 4+4+4 -->
       <div class="g span-4 reveal-l"><img src="images/photo-2025-05-22-09-40-54-7.jpg" alt="Buitenterras" loading="lazy" decoding="async"></div>


### PR DESCRIPTION
## Wat verandert er

Plaatst `niche_01_full.jpg` (detail van trapnis met terracotta kruik) in **Layout G** van de galerij, ongeveer halverwege (positie ~18 van 35).

### Layout-aanpassing
| | Voor | Na |
|---|---|---|
| Layout G | 4+8 (sideboard + avondsfeer) | 4+4+4 (sideboard + **niche** + avondsfeer) |

De avondsfeer-foto (nachtzwembad) wordt iets smaller (span-8 → span-4) maar blijft prominent.

## Test plan
- [ ] Galerij doorlopen op desktop — niche moet verschijnen tussen sideboard en avondsfeer
- [ ] Op iPhone checken — niche moet halverwege de scroll zichtbaar zijn
- [ ] Geen broken images

https://claude.ai/code/session_013UnB3bHaxkZnj5vBS3fQba

---
_Generated by [Claude Code](https://claude.ai/code/session_013UnB3bHaxkZnj5vBS3fQba)_