### PR TITLE
Fix orphan-foto's in galerij op tablet en landscape iPhone

### DIFF
--- a/index.html
+++ b/index.html
@@ -613,10 +613,8 @@
     .g.wide{ aspect-ratio: 16/9; }
 
     @media (max-width: 900px){
-      .g.span-8,.g.span-7{ grid-column: span 12; }
-      .g.span-5{ grid-column: span 6; }
+      .g.span-8,.g.span-7,.g.span-5,.g.span-4{ grid-column: span 12; }
       .g.span-6{ grid-column: span 6; }
-      .g.span-4{ grid-column: span 6; }
       .g.span-3{ grid-column: span 6; }
       .g.span-12{ aspect-ratio: 16/9; }
     }


### PR DESCRIPTION
## Probleem
Op iPhone in landscape modus (en op iPads) verscheen soms een foto half-breed met witte ruimte ernaast, gevolgd door een grote foto. Dat gebeurt op viewports tussen 560-900px omdat:

- Rijen van **3 foto's** (4+4+4) werden 6+6+6 → 2 in eerste rij, derde alleen met 6 cols leeg ernaast.
- Rijen van **ongelijke 2 foto's** (7+5, 8+4) werden 12+6 → tweede foto alleen met witruimte.

## Oplossing
Bij viewports 560-900px nu:
- **span-4, span-5, span-7, span-8** → full-width (1 foto per rij)
- **span-6** → blijft 2-koloms (6+6 perfect zonder witruimte)
- **span-3** → blijft 2-koloms (4-foto rij wordt 2×2 grid, perfect)

Zo komen er geen weeskinderen meer voor.

## Test plan
- [ ] iPhone in landscape — geen halve foto's meer met witte ruimte ernaast
- [ ] iPad portrait — zelfde
- [ ] iPhone portrait (<560px) — onveranderd, foto's stacken zoals voorheen
- [ ] Desktop (>900px) — galerij ziet er hetzelfde uit als nu

https://claude.ai/code/session_013UnB3bHaxkZnj5vBS3fQba

---
_Generated by [Claude Code](https://claude.ai/code/session_013UnB3bHaxkZnj5vBS3fQba)_